### PR TITLE
VS 2017 (15.7) /analyze cleanup

### DIFF
--- a/Binary/SOParser.h
+++ b/Binary/SOParser.h
@@ -32,11 +32,11 @@ class CSOParser
     char                                        m_pError[ MAX_ERROR_SIZE + 1 ];                 // Error buffer
 
 public:
-    CSOParser()
+    CSOParser() noexcept :
+        m_newEntry{},
+        m_SemanticString{},
+        m_pError{}
     {
-        ZeroMemory(&m_newEntry, sizeof(m_newEntry));
-        ZeroMemory(m_SemanticString, sizeof(m_SemanticString));
-        m_pError[0] = 0;
     }
 
     ~CSOParser()

--- a/Effect.h
+++ b/Effect.h
@@ -197,18 +197,18 @@ struct SType : public ID3DX11EffectType
     };
 
 
-    SType() :
+    SType() noexcept :
        VarType(EVT_Invalid),
        Elements(0),
        pTypeName(nullptr),
        TotalSize(0),
        Stride(0),
-       PackedSize(0)
+       PackedSize(0),
+       StructType{}
     {
         static_assert(sizeof(NumericType) <= sizeof(StructType), "SType union issue");
         static_assert(sizeof(ObjectType) <= sizeof(StructType), "SType union issue");
         static_assert(sizeof(InterfaceType) <= sizeof(StructType), "SType union issue");
-        ZeroMemory( &StructType, sizeof(StructType) );
     }
 
     bool IsEqual(SType *pOtherType) const;
@@ -289,6 +289,11 @@ struct SSingleElementType : public ID3DX11EffectType
     STDMETHOD_(LPCSTR, GetMemberSemantic)(uint32_t Index) override { return ((SType*)pType)->GetMemberSemantic(Index); }
 
     IUNKNOWN_IMP(SSingleElementType, ID3DX11EffectType, IUnknown);
+
+    SSingleElementType() noexcept :
+        pType(nullptr)
+    {
+    }
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -306,7 +311,7 @@ struct SBaseBlock
     uint32_t        AssignmentCount;
     SAssignment     *pAssignments;
 
-    SBaseBlock();
+    SBaseBlock() noexcept;
 
     bool ApplyAssignments(CEffect *pEffect);
 
@@ -354,7 +359,7 @@ struct STechnique : public ID3DX11EffectTechnique
     bool        InitiallyValid;
     bool        HasDependencies;
 
-    STechnique();
+    STechnique() noexcept;
 
     STDMETHOD_(bool, IsValid)() override;
     STDMETHOD(GetDesc)(_Out_ D3DX11_TECHNIQUE_DESC *pDesc) override;
@@ -383,7 +388,7 @@ struct SGroup : public ID3DX11EffectGroup
     bool        InitiallyValid;
     bool        HasDependencies;
 
-    SGroup();
+    SGroup() noexcept;
 
     STDMETHOD_(bool, IsValid)() override;
     STDMETHOD(GetDesc)(_Out_ D3DX11_GROUP_DESC *pDesc) override;
@@ -437,7 +442,7 @@ struct SPassBlock : SBaseBlock, public ID3DX11EffectPass
     bool        InitiallyValid;         // validity of all state objects and shaders in pass upon BindToDevice
     bool        HasDependencies;        // if pass expressions or pass state blocks have dependencies on variables (if true, IsValid != InitiallyValid possibly)
 
-    SPassBlock();
+    SPassBlock() noexcept;
 
     void ApplyPassAssignments();
     bool CheckShaderDependencies( _In_ const SShaderBlock* pBlock );
@@ -472,7 +477,7 @@ struct SDepthStencilBlock : SBaseBlock
     D3D11_DEPTH_STENCIL_DESC BackingStore;
     bool                     IsValid;
 
-    SDepthStencilBlock();
+    SDepthStencilBlock() noexcept;
 };
 
 struct SBlendBlock : SBaseBlock
@@ -481,7 +486,7 @@ struct SBlendBlock : SBaseBlock
     D3D11_BLEND_DESC        BackingStore;
     bool                    IsValid;
 
-    SBlendBlock();
+    SBlendBlock() noexcept;
 };
 
 struct SRasterizerBlock : SBaseBlock
@@ -490,7 +495,7 @@ struct SRasterizerBlock : SBaseBlock
     D3D11_RASTERIZER_DESC   BackingStore;
     bool                    IsValid;
 
-    SRasterizerBlock();
+    SRasterizerBlock() noexcept;
 };
 
 struct SSamplerBlock : SBaseBlock
@@ -503,16 +508,16 @@ struct SSamplerBlock : SBaseBlock
         SShaderResource     *pTexture;
     } BackingStore;
 
-    SSamplerBlock();
+    SSamplerBlock() noexcept;
 };
 
 struct SInterface
 {
     SClassInstanceGlobalVariable* pClassInstance;
 
-    SInterface()
+    SInterface() noexcept :
+        pClassInstance(nullptr)
     {
-        pClassInstance = nullptr;
     }
 };
 
@@ -520,36 +525,40 @@ struct SShaderResource
 {
     ID3D11ShaderResourceView *pShaderResource;
 
-    SShaderResource() 
+    SShaderResource() noexcept :
+        pShaderResource(nullptr)
     {
-        pShaderResource = nullptr;
     }
-
 };
 
 struct SUnorderedAccessView
 {
     ID3D11UnorderedAccessView *pUnorderedAccessView;
 
-    SUnorderedAccessView() 
+    SUnorderedAccessView() noexcept :
+        pUnorderedAccessView(nullptr)
     {
-        pUnorderedAccessView = nullptr;
     }
-
 };
 
 struct SRenderTargetView
 {
     ID3D11RenderTargetView *pRenderTargetView;
 
-    SRenderTargetView();
+    SRenderTargetView() noexcept :
+        pRenderTargetView(nullptr)
+    {
+    }
 };
 
 struct SDepthStencilView
 {
     ID3D11DepthStencilView *pDepthStencilView;
 
-    SDepthStencilView();
+    SDepthStencilView() noexcept :
+        pDepthStencilView(nullptr)
+    {
+    }
 };
 
 
@@ -561,12 +570,12 @@ template<class T, class D3DTYPE> struct SShaderDependency
     T       *ppFXPointers;              // Array of ptrs to FX objects (CBs, SShaderResources, etc)
     D3DTYPE *ppD3DObjects;              // Array of ptrs to matching D3D objects
 
-    SShaderDependency()
+    SShaderDependency() noexcept :
+        StartIndex(0),
+        Count(0),
+        ppFXPointers(nullptr),
+        ppD3DObjects(nullptr)
     {
-        StartIndex = Count = 0;
-
-        ppD3DObjects = nullptr;
-        ppFXPointers = nullptr;
     }
 };
 
@@ -645,7 +654,7 @@ struct SShaderBlock
     ID3DBlob                        *pInputSignatureBlob;   // The input signature is separated from the bytecode because it 
                                                             // is always available, even after Optimize() has been called.
 
-    SShaderBlock(SD3DShaderVTable *pVirtualTable = nullptr);
+    SShaderBlock(SD3DShaderVTable *pVirtualTable = nullptr) noexcept;
 
     EObjectType GetShaderType();
 
@@ -672,7 +681,10 @@ struct SString
 {
     char *pString;
 
-    SString();
+    SString() noexcept :
+        pString(nullptr)
+    {
+    }
 };
 
 
@@ -709,7 +721,7 @@ struct SVariable
     char                    *pSemantic;
     uint32_t                ExplicitBindPoint;
 
-    SVariable()
+    SVariable() noexcept
     {
         ZeroMemory(this, sizeof(*this));
         ExplicitBindPoint = uint32_t(-1);
@@ -728,7 +740,7 @@ struct SAnonymousShader : public TUncastableVariable<ID3DX11EffectShaderVariable
 {
     SShaderBlock    *pShaderBlock;
 
-    SAnonymousShader(_In_opt_ SShaderBlock *pBlock = nullptr);
+    SAnonymousShader(_In_opt_ SShaderBlock *pBlock = nullptr) noexcept;
 
     // ID3DX11EffectShaderVariable interface
     STDMETHOD_(bool, IsValid)() override;
@@ -816,27 +828,28 @@ struct SConstantBuffer : public TUncastableVariable<ID3DX11EffectConstantBuffer>
 
     CEffect                 *pEffect;
 
-    SConstantBuffer()
+    SConstantBuffer() noexcept :
+        pD3DObject(nullptr),
+        TBuffer{},
+        pBackingStore(nullptr),
+        Size(0),
+        pName(nullptr),
+        AnnotationCount(0),
+        pAnnotations(nullptr),
+        VariableCount(0),
+        pVariables(nullptr),
+        ExplicitBindPoint(uint32_t(-1)),
+        IsDirty(false),
+        IsTBuffer(false),
+        IsUserManaged(false),
+        IsEffectOptimized(false),
+        IsUsedByExpression(false),
+        IsUserPacked(false),
+        IsSingle(false),
+        IsNonUpdatable(false),
+        pMemberData(nullptr),
+        pEffect(nullptr)
     {
-        pD3DObject = nullptr;
-        ZeroMemory(&TBuffer, sizeof(TBuffer));
-        ExplicitBindPoint = uint32_t(-1);
-        pBackingStore = nullptr;
-        Size = 0;
-        pName = nullptr;
-        VariableCount = 0;
-        pVariables = nullptr;
-        AnnotationCount = 0;
-        pAnnotations = nullptr;
-        IsDirty = false;
-        IsTBuffer = false;
-        IsUserManaged = false;
-        IsEffectOptimized = false;
-        IsUsedByExpression = false;
-        IsUserPacked = false;
-        IsSingle = false;
-        IsNonUpdatable = false;
-        pEffect = nullptr;
     }
 
     bool ClonedSingle() const;
@@ -923,9 +936,9 @@ struct SAssignment
     {
         SGlobalVariable *pVariable;
 
-        SDependency()
+        SDependency() noexcept :
+            pVariable(nullptr)
         {
-            pVariable = nullptr;
         }
     };
 
@@ -954,19 +967,17 @@ struct SAssignment
         return IsObjectAssignmentHelper(LhsType);
     }
 
-    SAssignment()
+    SAssignment() noexcept :
+        LhsType(ELHS_Invalid),
+        AssignmentType(ERAT_Invalid),
+        LastRecomputedTime(0),
+        DependencyCount(0),
+        pDependencies(nullptr),
+        Destination{0},
+        Source{0},
+        DataSize(0),
+        MaxElements(0)
     {
-        LhsType = ELHS_Invalid;
-        AssignmentType = ERAT_Invalid;
-
-        Destination.pGeneric = nullptr;
-        Source.pGeneric = nullptr;
-
-        LastRecomputedTime = 0;
-        DependencyCount = 0;
-        pDependencies = nullptr;
-
-        DataSize = 0;
     }
 };
 
@@ -1035,7 +1046,7 @@ public:
         return (pData >= m_pData && pData < (m_pData + m_dwBufferSize));
     }
 
-    CEffectHeap();
+    CEffectHeap() noexcept;
     ~CEffectHeap();
 };
 
@@ -1197,7 +1208,7 @@ protected:
     friend struct SConstantBuffer;
 
 public:
-    CEffect( uint32_t Flags = 0 );
+    CEffect( uint32_t Flags = 0 ) noexcept;
     virtual ~CEffect();
     void ReleaseShaderRefection();
 

--- a/EffectLoad.cpp
+++ b/EffectLoad.cpp
@@ -182,7 +182,10 @@ inline HRESULT VerifyPointer(uint32_t oBase, uint32_t dwSize, uint32_t dwMaxSize
 // A simple class which assists in adding data to a block of memory
 //////////////////////////////////////////////////////////////////////////
 
-CEffectHeap::CEffectHeap() : m_pData(nullptr), m_dwSize(0), m_dwBufferSize(0)
+CEffectHeap::CEffectHeap() noexcept :
+    m_pData(nullptr),
+    m_dwSize(0),
+    m_dwBufferSize(0)
 {
 }
 
@@ -389,6 +392,35 @@ lExit:
 // CEffectLoader
 // A helper class which loads an effect
 //////////////////////////////////////////////////////////////////////////
+
+CEffectLoader::CEffectLoader() noexcept :
+    m_pData(nullptr),
+    m_pHeader(nullptr),
+    m_Version(0),
+    m_pEffect(nullptr),
+    m_pReflection(nullptr),
+    m_dwBufferSize(0),
+    m_pOldVars(nullptr),
+    m_pOldShaders(nullptr),
+    m_pOldDS(nullptr),
+    m_pOldAB(nullptr),
+    m_pOldRS(nullptr),
+    m_pOldCBs(nullptr),
+    m_pOldSamplers(nullptr),
+    m_OldInterfaceCount(0),
+    m_pOldInterfaces(nullptr),
+    m_pOldShaderResources(nullptr),
+    m_pOldUnorderedAccessViews(nullptr),
+    m_pOldRenderTargetViews(nullptr),
+    m_pOldDepthStencilViews(nullptr),
+    m_pOldStrings(nullptr),
+    m_pOldMemberDataBlocks(nullptr),
+    m_pvOldMemberInterfaces(nullptr),
+    m_pOldGroups(nullptr),
+    m_EffectMemory(0),
+    m_ReflectionMemory(0)
+{
+}
 
 _Use_decl_annotations_
 HRESULT CEffectLoader::GetUnstructuredDataBlock(uint32_t offset, uint32_t  *pdwSize, void **ppData)

--- a/EffectLoad.h
+++ b/EffectLoad.h
@@ -32,6 +32,12 @@ struct SRange
     uint32_t              start;
     uint32_t              last;
     CEffectVector<void *> vResources; // should be (last - start) in length, resource type depends on the range type
+
+    SRange() noexcept :
+        start(0),
+        last(0)
+    {
+    }
 };
 
 // Used during load to validate assignments
@@ -73,7 +79,7 @@ protected:
     SRasterizerBlock            *m_pOldRS;
     SConstantBuffer             *m_pOldCBs;
     SSamplerBlock               *m_pOldSamplers;
-    uint32_t                        m_OldInterfaceCount;
+    uint32_t                     m_OldInterfaceCount;
     SInterface                  *m_pOldInterfaces;
     SShaderResource             *m_pOldShaderResources;
     SUnorderedAccessView        *m_pOldUnorderedAccessViews;
@@ -143,10 +149,11 @@ protected:
     HRESULT GetUnstructuredDataBlock(_In_ uint32_t offset, _Out_ uint32_t *pdwSize, _Outptr_result_buffer_(*pdwSize) void **ppData);
     // This function makes a copy of the array of SInterfaceParameters, but not a copy of the strings
     HRESULT GetInterfaceParametersAndAddToReflection( _In_ uint32_t InterfaceCount, _In_ uint32_t offset, _Outptr_result_buffer_all_maybenull_(InterfaceCount) SShaderBlock::SInterfaceParameter **ppInterfaces );
+
 public:
+    CEffectLoader() noexcept;
 
     HRESULT LoadEffect(_In_ CEffect *pEffect, _In_reads_bytes_(cbEffectBuffer) const void *pEffectBuffer, _In_ uint32_t cbEffectBuffer);
 };
-
 
 }

--- a/EffectNonRuntime.cpp
+++ b/EffectNonRuntime.cpp
@@ -20,53 +20,52 @@ namespace D3DX11Effects
 
 extern SUnorderedAccessView g_NullUnorderedAccessView;
 
-SBaseBlock::SBaseBlock()
-: BlockType(EBT_Invalid)
-, IsUserManaged(false)
-, AssignmentCount(0)
-, pAssignments(nullptr)
-{
-
-}
-
-SPassBlock::SPassBlock()
-{
-    pName = nullptr;
-    AnnotationCount = 0;
-    pAnnotations = nullptr;
-    InitiallyValid = true;
-    HasDependencies = false;
-    ZeroMemory(&BackingStore, sizeof(BackingStore));
-}
-
-STechnique::STechnique()
-: pName(nullptr)
-, PassCount(0)
-, pPasses(nullptr)
-, AnnotationCount(0)
-, pAnnotations(nullptr)
-, InitiallyValid( true )
-, HasDependencies( false )
+SBaseBlock::SBaseBlock() noexcept :
+    BlockType(EBT_Invalid),
+    IsUserManaged(false),
+    AssignmentCount(0),
+    pAssignments(nullptr)
 {
 }
 
-SGroup::SGroup()
-: pName(nullptr)
-, TechniqueCount(0)
-, pTechniques(nullptr)
-, AnnotationCount(0)
-, pAnnotations(nullptr)
-, InitiallyValid( true )
-, HasDependencies( false )
+SPassBlock::SPassBlock() noexcept :
+    BackingStore{},
+    pName(nullptr),
+    AnnotationCount(0),
+    pAnnotations(nullptr),
+    pEffect(nullptr),
+    InitiallyValid(true),
+    HasDependencies(false)
 {
 }
 
-SDepthStencilBlock::SDepthStencilBlock()
+STechnique::STechnique() noexcept :
+    pName(nullptr),
+    PassCount(0),
+    pPasses(nullptr),
+    AnnotationCount(0),
+    pAnnotations(nullptr),
+    InitiallyValid( true ),
+    HasDependencies( false )
 {
-    pDSObject = nullptr;
-    ZeroMemory(&BackingStore, sizeof(BackingStore));
-    IsValid = true;
+}
 
+SGroup::SGroup() noexcept :
+    pName(nullptr),
+    TechniqueCount(0),
+    pTechniques(nullptr),
+    AnnotationCount(0),
+    pAnnotations(nullptr),
+    InitiallyValid( true ),
+    HasDependencies( false )
+{
+}
+
+SDepthStencilBlock::SDepthStencilBlock() noexcept :
+    pDSObject(nullptr),
+    BackingStore{},
+    IsValid(true)
+{
     BackingStore.BackFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
     BackingStore.BackFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
     BackingStore.BackFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
@@ -83,12 +82,11 @@ SDepthStencilBlock::SDepthStencilBlock()
     BackingStore.StencilWriteMask = D3D11_DEFAULT_STENCIL_WRITE_MASK;
 }
 
-SBlendBlock::SBlendBlock()
+SBlendBlock::SBlendBlock() noexcept :
+    pBlendObject(nullptr),
+    BackingStore{},
+    IsValid(true)
 {
-    pBlendObject = nullptr;
-    ZeroMemory(&BackingStore, sizeof(BackingStore));
-    IsValid = true;
-
     BackingStore.AlphaToCoverageEnable = false;
     BackingStore.IndependentBlendEnable = true;
     for( size_t i=0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++ )
@@ -103,12 +101,11 @@ SBlendBlock::SBlendBlock()
     }
 }
 
-SRasterizerBlock::SRasterizerBlock()
+SRasterizerBlock::SRasterizerBlock() noexcept :
+    pRasterizerObject(nullptr),
+    BackingStore{},
+    IsValid(true)
 {
-    pRasterizerObject = nullptr;
-    ZeroMemory(&BackingStore, sizeof(BackingStore));
-    IsValid = true;
-
     BackingStore.AntialiasedLineEnable = false;
     BackingStore.CullMode = D3D11_CULL_BACK;
     BackingStore.DepthBias = D3D11_DEFAULT_DEPTH_BIAS;
@@ -121,11 +118,10 @@ SRasterizerBlock::SRasterizerBlock()
     BackingStore.DepthClipEnable = true;
 }
 
-SSamplerBlock::SSamplerBlock()
+SSamplerBlock::SSamplerBlock() noexcept :
+    pD3DObject(nullptr),
+    BackingStore{}
 {
-    pD3DObject = nullptr;
-    ZeroMemory(&BackingStore, sizeof(BackingStore));
-
     BackingStore.SamplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
     BackingStore.SamplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
     BackingStore.SamplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
@@ -141,35 +137,25 @@ SSamplerBlock::SSamplerBlock()
     BackingStore.SamplerDesc.MaxLOD = FLT_MAX;
 }
 
-SShaderBlock::SShaderBlock(SD3DShaderVTable *pVirtualTable)
+SShaderBlock::SShaderBlock(SD3DShaderVTable *pVirtualTable) noexcept :
+    IsValid(true),
+    pVT(pVirtualTable),
+    pReflectionData(nullptr),
+    pD3DObject(nullptr),
+    CBDepCount(0),
+    pCBDeps(nullptr),
+    SampDepCount(0),
+    pSampDeps(nullptr),
+    InterfaceDepCount(0),
+    pInterfaceDeps(nullptr),
+    ResourceDepCount(0),
+    pResourceDeps(nullptr),
+    UAVDepCount(0),
+    pUAVDeps(nullptr),
+    TBufferDepCount(0),
+    ppTbufDeps(nullptr),
+    pInputSignatureBlob(nullptr)
 {
-    IsValid = true;
-
-    pVT = pVirtualTable;
-
-    pReflectionData = nullptr;
-    
-    pD3DObject = nullptr;
-
-    CBDepCount = 0;
-    pCBDeps = nullptr;
-
-    SampDepCount = 0;
-    pSampDeps = nullptr;
-
-    InterfaceDepCount = 0;
-    pInterfaceDeps = nullptr;
-
-    ResourceDepCount = 0;
-    pResourceDeps = nullptr;
-
-    UAVDepCount = 0;
-    pUAVDeps = nullptr;
-
-    TBufferDepCount = 0;
-    ppTbufDeps = nullptr;
-
-    pInputSignatureBlob = nullptr;
 }
 
 HRESULT SShaderBlock::OnDeviceBind()
@@ -615,21 +601,6 @@ lExit:
     return hr;
 }
 
-SString::SString()
-{
-    pString = nullptr;
-}
-
-SRenderTargetView::SRenderTargetView()
-{
-    pRenderTargetView = nullptr;
-}
-
-SDepthStencilView::SDepthStencilView()
-{
-    pDepthStencilView = nullptr;
-}
-
 void * GetBlockByIndex(EVarType VarType, EObjectType ObjectType, void *pBaseBlock, uint32_t Index)
 {
     switch( VarType )
@@ -705,58 +676,54 @@ void * GetBlockByIndex(EVarType VarType, EObjectType ObjectType, void *pBaseBloc
 // CEffect
 //--------------------------------------------------------------------------------------
 
-CEffect::CEffect( uint32_t Flags )
+CEffect::CEffect( uint32_t Flags ) noexcept :
+    m_RefCount(1),
+    m_Flags(Flags),
+    m_pReflection(nullptr),
+    m_VariableCount(0),
+    m_pVariables(nullptr),
+    m_AnonymousShaderCount(0),
+    m_pAnonymousShaders(nullptr),
+    m_TechniqueCount(0),
+    m_GroupCount(0),
+    m_pGroups(nullptr),
+    m_pNullGroup(nullptr),
+    m_ShaderBlockCount(0),
+    m_pShaderBlocks(nullptr),
+    m_DepthStencilBlockCount(0),
+    m_pDepthStencilBlocks(nullptr),
+    m_BlendBlockCount(0),
+    m_pBlendBlocks(nullptr),
+    m_RasterizerBlockCount(0),
+    m_pRasterizerBlocks(nullptr),
+    m_SamplerBlockCount(0),
+    m_pSamplerBlocks(nullptr),
+    m_MemberDataCount(0),
+    m_pMemberDataBlocks(nullptr),
+    m_InterfaceCount(0),
+    m_pInterfaces(nullptr),
+    m_CBCount(0),
+    m_pCBs(nullptr),
+    m_StringCount(0),
+    m_pStrings(nullptr),
+    m_ShaderResourceCount(0),
+    m_pShaderResources(nullptr),
+    m_UnorderedAccessViewCount(0),
+    m_pUnorderedAccessViews(nullptr),
+    m_RenderTargetViewCount(0),
+    m_pRenderTargetViews(nullptr),
+    m_DepthStencilViewCount(0),
+    m_pDepthStencilViews(nullptr),
+    m_LocalTimer(1),
+    m_FXLIndex(0),
+    m_pDevice(nullptr),
+    m_pContext(nullptr),
+    m_pClassLinkage(nullptr),
+    m_pTypePool(nullptr),
+    m_pStringPool(nullptr),
+    m_pPooledHeap(nullptr),
+    m_pOptimizedTypeHeap(nullptr)
 {
-    m_RefCount = 1;
-
-    m_pVariables = nullptr;
-    m_pAnonymousShaders = nullptr;
-    m_pGroups = nullptr;
-    m_pNullGroup = nullptr;
-    m_pShaderBlocks = nullptr;
-    m_pDepthStencilBlocks = nullptr;
-    m_pBlendBlocks = nullptr;
-    m_pRasterizerBlocks = nullptr;
-    m_pSamplerBlocks = nullptr;
-    m_pCBs = nullptr;
-    m_pStrings = nullptr;
-    m_pMemberDataBlocks = nullptr;
-    m_pInterfaces = nullptr;
-    m_pShaderResources = nullptr;
-    m_pUnorderedAccessViews = nullptr;
-    m_pRenderTargetViews = nullptr;
-    m_pDepthStencilViews = nullptr;
-    m_pDevice = nullptr;
-    m_pClassLinkage = nullptr;
-    m_pContext = nullptr;
-
-    m_VariableCount = 0;
-    m_AnonymousShaderCount = 0;
-    m_ShaderBlockCount = 0;
-    m_DepthStencilBlockCount = 0;
-    m_BlendBlockCount = 0;
-    m_RasterizerBlockCount = 0;
-    m_SamplerBlockCount = 0;
-    m_StringCount = 0;
-    m_MemberDataCount = 0;
-    m_InterfaceCount = 0;
-    m_ShaderResourceCount = 0;
-    m_UnorderedAccessViewCount = 0;
-    m_RenderTargetViewCount = 0;
-    m_DepthStencilViewCount = 0;
-    m_CBCount = 0;
-    m_TechniqueCount = 0;
-    m_GroupCount = 0;
-
-    m_pReflection = nullptr;
-    m_LocalTimer = 1;
-    m_Flags = Flags;
-    m_FXLIndex = 0;
-
-    m_pTypePool = nullptr;
-    m_pStringPool = nullptr;
-    m_pPooledHeap = nullptr;
-    m_pOptimizedTypeHeap = nullptr;
 }
 
 void CEffect::ReleaseShaderRefection()

--- a/EffectReflection.cpp
+++ b/EffectReflection.cpp
@@ -596,7 +596,8 @@ lExit:
 // ID3DX11EffectShaderVariable (SAnonymousShader implementation)
 ////////////////////////////////////////////////////////////////////////////////
 
-SAnonymousShader::SAnonymousShader(_In_opt_ SShaderBlock *pBlock) : pShaderBlock(pBlock)
+SAnonymousShader::SAnonymousShader(_In_opt_ SShaderBlock *pBlock) noexcept :
+    pShaderBlock(pBlock)
 {
 }
 

--- a/EffectVariable.inl
+++ b/EffectVariable.inl
@@ -1181,7 +1181,8 @@ struct TTopLevelVariable : public SVariable, public IBaseInterface
         return pEffect;
     }
 
-    TTopLevelVariable() : pEffect (nullptr)
+    TTopLevelVariable() noexcept :
+        pEffect(nullptr)
     {
     }
 
@@ -1220,10 +1221,10 @@ struct TMember : public SVariable, public IBaseInterface
     // Required to create member/element variable interfaces
     TTopLevelVariable<ID3DX11EffectVariable>    *pTopLevelEntity;
 
-    TMember()
+    TMember() noexcept :
+        IsSingleElement(false),
+        pTopLevelEntity(nullptr)
     {
-        IsSingleElement = false;
-        pTopLevelEntity = nullptr;
     }
 
     CEffect* GetEffect()
@@ -1390,10 +1391,10 @@ struct TGlobalVariable : public TVariable<TTopLevelVariable<IBaseInterface> >
     // if numeric, pointer to the constant buffer where this variable lives
     SConstantBuffer *pCB;
 
-    uint32_t            AnnotationCount;
+    uint32_t        AnnotationCount;
     SAnnotation     *pAnnotations;
 
-    TGlobalVariable() :
+    TGlobalVariable() noexcept :
         LastModifiedTime(0),
         pCB(nullptr),
         AnnotationCount(0),

--- a/d3dxGlobal.cpp
+++ b/d3dxGlobal.cpp
@@ -23,7 +23,10 @@ namespace D3DX11Core
 // CMemoryStream - A class to simplify reading binary data
 //////////////////////////////////////////////////////////////////////////
 
-CMemoryStream::CMemoryStream() : m_pData(nullptr), m_cbData(0), m_readPtr(0)
+CMemoryStream::CMemoryStream() noexcept :
+    m_pData(nullptr),
+    m_cbData(0),
+    m_readPtr(0)
 {
 }
 
@@ -124,7 +127,7 @@ HRESULT CMemoryStream::Seek(_In_ size_t offset)
 // CDataBlock - used to dynamically build up the effect file in memory
 //////////////////////////////////////////////////////////////////////////
 
-CDataBlock::CDataBlock() :
+CDataBlock::CDataBlock() noexcept :
     m_size(0),
     m_maxSize(0),
     m_pData(nullptr),
@@ -251,7 +254,7 @@ void* CDataBlock::Allocate(uint32_t bufferSize, CDataBlock **ppBlock)
 
 //////////////////////////////////////////////////////////////////////////
 
-CDataBlockStore::CDataBlockStore() :
+CDataBlockStore::CDataBlockStore() noexcept :
     m_pFirst(nullptr),
     m_pLast(nullptr),
     m_Size(0),

--- a/inc/d3dxGlobal.h
+++ b/inc/d3dxGlobal.h
@@ -114,7 +114,7 @@ public:
     size_t  GetPosition();
     HRESULT Seek(_In_ size_t offset);
 
-    CMemoryStream();
+    CMemoryStream() noexcept;
     ~CMemoryStream();
 };
 
@@ -196,7 +196,11 @@ protected:
 public:
     HRESULT m_hLastError;
 
-    CEffectVector<T>() : m_hLastError(S_OK), m_pData(nullptr), m_CurSize(0), m_MaxSize(0)
+    CEffectVector<T>() noexcept :
+        m_hLastError(S_OK),
+        m_pData(nullptr),
+        m_CurSize(0),
+        m_MaxSize(0)
     {
 #if _DEBUG
         m_pCastData = nullptr;
@@ -473,7 +477,9 @@ template <class T, T MaxValue> class CheckedNumber
     bool    m_bValid;
 
 public:
-    CheckedNumber<T, MaxValue>() : m_Value(0), m_bValid(true)
+    CheckedNumber<T, MaxValue>() noexcept :
+        m_Value(0),
+        m_bValid(true)
     {
     }
 
@@ -576,7 +582,7 @@ public:
 
     void    EnableAlignment();
 
-    CDataBlock();
+    CDataBlock() noexcept;
     ~CDataBlock();
 
     friend class CDataBlockStore;
@@ -609,7 +615,7 @@ public:
     uint32_t GetSize();
     void    EnableAlignment();
 
-    CDataBlockStore();
+    CDataBlockStore() noexcept;
     ~CDataBlockStore();
 };
 
@@ -834,7 +840,11 @@ public:
         }
     };
 
-    CEffectHashTable() : m_rgpHashEntries(nullptr), m_NumHashSlots(0), m_NumEntries(0), m_bOwnHashEntryArray(false)
+    CEffectHashTable() noexcept :
+        m_rgpHashEntries(nullptr),
+        m_NumHashSlots(0),
+        m_NumEntries(0),
+        m_bOwnHashEntryArray(false)
     {
     }
 
@@ -1230,9 +1240,9 @@ protected:
     CDataBlockStore *m_pPrivateHeap;
 
 public:
-    CEffectHashTableWithPrivateHeap()
+    CEffectHashTableWithPrivateHeap() noexcept :
+        m_pPrivateHeap(nullptr)
     {
-        m_pPrivateHeap = nullptr;
     }
 
     void Cleanup()


### PR DESCRIPTION
Primarily adding ``noexcept`` to default constructors, and updating initializer lists