### PR TITLE
Add D3DX11DebugMute

### DIFF
--- a/d3dxGlobal.cpp
+++ b/d3dxGlobal.cpp
@@ -367,14 +367,26 @@ uint32_t CDataBlockStore::GetSize()
 
 //////////////////////////////////////////////////////////////////////////
 
+static bool s_mute = false;
+
+bool D3DX11DebugMute(bool mute)
+{
+    bool previous = s_mute;
+    s_mute = mute;
+    return previous;
+}
+
 #ifdef _DEBUG
 _Use_decl_annotations_
 void __cdecl D3DXDebugPrintf(UINT lvl, LPCSTR szFormat, ...)
 {
+    if (s_mute)
+        return;
+
     UNREFERENCED_PARAMETER(lvl);
 
-    char strA[4096];
-    char strB[4096];
+    char strA[4096] = {};
+    char strB[4096] = {};
 
     va_list ap;
     va_start(ap, szFormat);

--- a/inc/d3dx11effect.h
+++ b/inc/d3dx11effect.h
@@ -1191,6 +1191,23 @@ HRESULT D3DX11CompileEffectFromFile( _In_z_ LPCWSTR pFileName,
                                      _Out_ ID3DX11Effect **ppEffect,
                                      _Outptr_opt_result_maybenull_ ID3DBlob **ppErrors );
 
+
+//----------------------------------------------------------------------------
+// D3DX11DebugMute
+//
+// Controls the output of diagnostic information in DEBUG builds. No effect
+// in RELEASE builds.
+//
+// Returns the previous state so you can do temporary suppression like:
+//
+//    bool oldmute = D3DX11DebugMute(true);
+//    ...
+//    D3DX11DebugMute(oldmute);
+//
+//----------------------------------------------------------------------------
+
+bool D3DX11DebugMute(bool mute);
+
 #ifdef __cplusplus
 }
 #endif //__cplusplus


### PR DESCRIPTION
The Effects 11 outputs a lot of diagnostic message in ``_DEBUG`` builds, but there was no way to suppress what amounts to warnings/info messages where you are aware of the issue and are handling it.

This adds a very basic solution like was available in D3DX9 with the [D3DXDebugMute](https://docs.microsoft.com/en-us/windows/desktop/direct3d9/d3dxdebugmute) function.

> Note that unlike the D3DX9 version, this ``D3DX11DebugMute`` function does not attempt to suppress diagnostic output from Direct3D, DXGI, etc. You should continue to use the existing ``ID3D11InfoQueue``  and ``IDXGIInfoQueue`` interfaces for that.