### PR TITLE
CMake update to use /ZH:SHA_256 for clang v16 or later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,11 @@ if(MSVC)
       target_compile_options(${PROJECT_NAME} PRIVATE "/Qspectre")
     endif()
 
+    if((MSVC_VERSION GREATER_EQUAL 1924)
+       AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)))
+      target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
+    endif()
+
     if((MSVC_VERSION GREATER_EQUAL 1928)
        AND (CMAKE_SIZEOF_VOID_P EQUAL 8)
        AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)))
@@ -152,10 +157,6 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
       message(STATUS "Building using Whole Program Optimization")
       target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
-    endif()
-
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
-        target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.26)


### PR DESCRIPTION
Support for "SHA256" hashing of PDBs is required for SDL compliance, and is supported by VS 2019 or later. Support for this switch was added to clang/LLVM for Windows v16 which is coming in VS 2022 17.6.