### PR TITLE
ADO pipeline changes for OpenSSF Best Practices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     target_compile_options(${PROJECT_NAME} PRIVATE /wd5205 /sdl /JMC- /Zc:__cplusplus /Zc:inline)
 
     if(ENABLE_CODE_ANALYSIS)
-      target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
+      target_compile_options(${PROJECT_NAME} PRIVATE /analyze /WX)
     endif()
 
     if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)

--- a/EffectLoad.cpp
+++ b/EffectLoad.cpp
@@ -2476,7 +2476,9 @@ HRESULT CEffectLoader::LoadAnnotations(uint32_t  *pcAnnotations, SAnnotation **p
         
         // we allocate raw bytes for annotations because they are polymorphic types that need to be placement new'ed
         VN( pAnnotations = (SAnnotation *) PRIVATENEW uint8_t[annotationsSize] );
-        
+
+        memset(pAnnotations, 0, annotationsSize);
+
         for (i=0; i<cAnnotations; i++)
         {
             SBinaryAnnotation *psAnnotation;

--- a/Effects11_Windows10.sln
+++ b/Effects11_Windows10.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.33927.289
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34902.65
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Effects11", "Effects11_Windows10.vcxproj", "{9188BD60-F60C-4A40-98CF-F704E467D775}"
 EndProject

--- a/Effects11_Windows10.vcxproj
+++ b/Effects11_Windows10.vcxproj
@@ -66,39 +66,39 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ All content and source code for this package are subject to the terms of the [MI
 
 ## Release Notes
 
+FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/FX11/security/advisories).
+
+For a full change history, see [CHANGELOG.md](https://github.com/microsoft/FX11/blob/main/CHANGELOG.md).
+
 * The library can be built with Visual C++ or with clang/LLVM for Windows. The code is not conformant enough to support the GNUC (MinGW) compiler.
 
 ## Support

--- a/build/FX11-GitHub-Dev17.yml
+++ b/build/FX11-GitHub-Dev17.yml
@@ -5,15 +5,28 @@
 
 # Builds the library for Windows Desktop.
 
-trigger: none
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    exclude:
+    - '*.md'
+    - LICENSE
+    - CMake*
+    - build/*.in
 
 pr:
   branches:
     include:
     - main
   paths:
-    include:
-    - build/FX11-GitHub-Dev17.yml
+    exclude:
+    - '*.md'
+    - LICENSE
+    - CMake*
+    - build/*.in
+  drafts: false
 
 resources:
   repositories:
@@ -107,5 +120,62 @@ jobs:
       solution: Effects11_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
       platform: x64
+      configuration: Release
+      msbuildArchitecture: x64
+
+- job: UWP_BUILD
+  displayName: 'Universal Windows Platform (UWP)'
+  timeoutInMinutes: 120
+  cancelTimeoutInMinutes: 1
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+  - task: VSBuild@1
+    displayName: Build solution Effects11_Windows10.sln 32dbg
+    inputs:
+      solution: Effects11_Windows10.sln
+      msbuildArgs: /p:PreferredToolArchitecture=x64
+      platform: x86
+      configuration: Debug
+      msbuildArchitecture: x64
+  - task: VSBuild@1
+    displayName: Build solution Effects11_Windows10.sln 32rel
+    inputs:
+      solution: Effects11_Windows10.sln
+      msbuildArgs: /p:PreferredToolArchitecture=x64
+      platform: x86
+      configuration: Release
+      msbuildArchitecture: x64
+  - task: VSBuild@1
+    displayName: Build solution Effects11_Windows10.sln 64dbg
+    inputs:
+      solution: Effects11_Windows10.sln
+      msbuildArgs: /p:PreferredToolArchitecture=x64
+      platform: x64
+      configuration: Debug
+      msbuildArchitecture: x64
+  - task: VSBuild@1
+    displayName: Build solution Effects11_Windows10.sln 64rel
+    inputs:
+      solution: Effects11_Windows10.sln
+      msbuildArgs: /p:PreferredToolArchitecture=x64
+      platform: x64
+      configuration: Release
+      msbuildArchitecture: x64
+  - task: VSBuild@1
+    displayName: Build solution Effects11_Windows10.sln arm64dbg
+    inputs:
+      solution: Effects11_Windows10.sln
+      msbuildArgs: /p:PreferredToolArchitecture=x64
+      platform: ARM64
+      configuration: Debug
+      msbuildArchitecture: x64
+  - task: VSBuild@1
+    displayName: Build solution Effects11_Windows10.sln arm64rel
+    inputs:
+      solution: Effects11_Windows10.sln
+      msbuildArgs: /p:PreferredToolArchitecture=x64
+      platform: ARM64
       configuration: Release
       msbuildArchitecture: x64

--- a/build/FX11-SDL.yml
+++ b/build/FX11-SDL.yml
@@ -13,7 +13,14 @@ schedules:
     - main
 
 trigger: none
-pr: none
+
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/FX11-SDL.yml
 
 resources:
   repositories:
@@ -26,6 +33,7 @@ name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 variables:
   Codeql.Enabled: true
   Codeql.Language: cpp
+  VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
   VS_GENERATOR: 'Visual Studio 17 2022'
 
 pool:
@@ -98,3 +106,37 @@ jobs:
       GdnBreakPolicyMinSev: 'Error'
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Detection
+
+- job: VC_PREFAST
+  displayName: 'Build using /analyze (PREFAST)'
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+  - task: CmdLine@2
+    displayName: Setup environment for CMake to use VS
+    inputs:
+      script: |
+        call "$(VC_PATH)\Auxiliary\Build\vcvars64.bat"
+        echo ##vso[task.setvariable variable=WindowsSdkVerBinPath;]%WindowsSdkVerBinPath%
+        echo ##vso[task.prependpath]%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
+        echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
+        echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
+        echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
+        echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
+        echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
+        echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
+        echo ##vso[task.setvariable variable=LIB;]%LIB%
+
+  - task: CMake@1
+    displayName: CMake Config
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --preset=x64-Debug -DENABLE_CODE_ANALYSIS=ON
+  - task: CMake@1
+    displayName: CMake Build
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out/build/x64-Debug


### PR DESCRIPTION
Adds use of ``/analyze`` to the SDL pipeline.

Move UWP projects to VS 2022 toolset.