### PR TITLE
Cleanup of ADO pipeline YAML files 

### DIFF
--- a/.azuredevops/pipelines/FX11-GitHub-CMake-Dev17.yml
+++ b/.azuredevops/pipelines/FX11-GitHub-CMake-Dev17.yml
@@ -13,7 +13,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
 
 pr:
   branches:
@@ -23,7 +23,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
   drafts: false
 
 resources:

--- a/.azuredevops/pipelines/FX11-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/FX11-GitHub-CMake.yml
@@ -13,7 +13,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
 
 pr:
   branches:
@@ -23,7 +23,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
 
 resources:
   repositories:

--- a/.azuredevops/pipelines/FX11-GitHub-Dev17.yml
+++ b/.azuredevops/pipelines/FX11-GitHub-Dev17.yml
@@ -38,138 +38,90 @@ pool:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 60
+  strategy:
+    maxParallel: 4
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_x86:
+        BuildPlatform: Win32
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_x86:
+        BuildPlatform: Win32
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_x64_SpectreMitigated:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_x64_SpectreMitigated:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
+      Release_x86_SpectreMitigated:
+        BuildPlatform: Win32
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_x86_SpectreMitigated:
+        BuildPlatform: Win32
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution Effects11_2022_Win10.sln 32dbg
+    displayName: Build solution Effects11_2022_Win10.sln
     inputs:
       solution: Effects11_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Win32
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2022_Win10.sln 32rel
-    inputs:
-      solution: Effects11_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Win32
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2022_Win10.sln 64dbg
-    inputs:
-      solution: Effects11_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2022_Win10.sln 64rel
-    inputs:
-      solution: Effects11_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-
-- job: DESKTOP_BUILD_SPECTRE
-  displayName: 'Win32 Desktop (Spectre-mitigated)'
-  timeoutInMinutes: 60
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2022_Win10.sln 32dbg
-    inputs:
-      solution: Effects11_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: Win32
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2022_Win10.sln 32rel
-    inputs:
-      solution: Effects11_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: Win32
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2022_Win10.sln 64dbg
-    inputs:
-      solution: Effects11_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2022_Win10.sln 64rel
-    inputs:
-      solution: Effects11_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x64
-      configuration: Release
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=$(SpectreMitigation)
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution Effects11_Windows10.sln 32dbg
+    displayName: Build solution Effects11_Windows10.sln
     inputs:
       solution: Effects11_Windows10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_Windows10.sln 32rel
-    inputs:
-      solution: Effects11_Windows10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_Windows10.sln 64dbg
-    inputs:
-      solution: Effects11_Windows10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_Windows10.sln 64rel
-    inputs:
-      solution: Effects11_Windows10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_Windows10.sln arm64dbg
-    inputs:
-      solution: Effects11_Windows10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution Effects11_Windows10.sln arm64rel
-    inputs:
-      solution: Effects11_Windows10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/.azuredevops/pipelines/FX11-GitHub.yml
+++ b/.azuredevops/pipelines/FX11-GitHub.yml
@@ -38,73 +38,51 @@ pool:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 60
+  strategy:
+    maxParallel: 4
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_x86:
+        BuildPlatform: Win32
+        BuildConfiguration: Release
+        SpectreMitigation: false
+      Debug_x86:
+        BuildPlatform: Win32
+        BuildConfiguration: Debug
+        SpectreMitigation: false
+      Release_x64_SpectreMitigated:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_x64_SpectreMitigated:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
+      Release_x86_SpectreMitigated:
+        BuildPlatform: Win32
+        BuildConfiguration: Release
+        SpectreMitigation: 'Spectre'
+      Debug_x86_SpectreMitigated:
+        BuildPlatform: Win32
+        BuildConfiguration: Debug
+        SpectreMitigation: 'Spectre'
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution Effects11_2019_Win10.sln 32dbg
+    displayName: Build solution Effects11_2019_Win10.sln
     inputs:
       solution: Effects11_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Win32
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2019_Win10.sln 32rel
-    inputs:
-      solution: Effects11_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Win32
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2019_Win10.sln 64dbg
-    inputs:
-      solution: Effects11_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2019_Win10.sln 64rel
-    inputs:
-      solution: Effects11_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-
-- job: DESKTOP_BUILD_SPECTRE
-  displayName: 'Win32 Desktop (Spectre-mitigated)'
-  timeoutInMinutes: 60
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2019_Win10.sln 32dbg
-    inputs:
-      solution: Effects11_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: Win32
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2019_Win10.sln 32rel
-    inputs:
-      solution: Effects11_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: Win32
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2019_Win10.sln 64dbg
-    inputs:
-      solution: Effects11_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution Effects11_2019_Win10.sln 64rel
-    inputs:
-      solution: Effects11_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=Spectre
-      platform: x64
-      configuration: Release
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:SpectreMitigation=$(SpectreMitigation)
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,12 +8,17 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
   schedule:
     - cron: '21 22 * * 6'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,17 @@ name: 'CMake (Windows)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
 
 permissions:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,12 +8,17 @@ name: MSBuild
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
 
 permissions:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -8,11 +8,16 @@ name: Microsoft C++ Code Analysis
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - '.azuredevops/**'
+      - LICENSE
+      - '.nuget/*'
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - LICENSE
       - '.nuget/*'
   schedule:


### PR DESCRIPTION
This PR adds the use of strategy to the existing ADO pipelines.

* For the basic builds using Visual Studio MSBuild with minimal job setup, I made use of `strategy` `matrix` to simplify the pipelines for GitHub and GitHub-Dev17.

> Also updated pipeline trigger path filters: GHA should ignore everything under ``.azuredevops``, and ADO should ignore everything under ``.github``.
